### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Generate a false colour index spectrogram to nicely visualise long duration soun
 It is assumed that a series of 1 minute files are stored in ./input_audio/ dir
 
 If you have long duration recordings, to split into individual files use ffmpeg:
-`ffmpeg -i long_input_file.wav -f segment -segment_time 60 -c copy short_output_file_%02d.wav`
+`ffmpeg -i long_input_file.wav -f segment -segment_time 60 -c copy short_output_file_%06d.wav`
 then transfer these one minute files to ./input_audio/ and you're ready to go
 
 Numpy ndarrays storing individual index spectrograms are stored in ./output_spectrograms/ dir


### PR DESCRIPTION
Tiny split command fix; if you don't add enough 0s the default file sort will make the sound file appear "out of order" for anything longer than 99 minutes. (e.g. short_output_file_101 will appear before short_output_file_20)